### PR TITLE
Use protocol relative URL for highlight JS

### DIFF
--- a/default.twig
+++ b/default.twig
@@ -68,7 +68,7 @@
 
         <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
         <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
-        <script src="http://yastatic.net/highlightjs/8.2/highlight.min.js"></script>
+        <script src="//yastatic.net/highlightjs/8.2/highlight.min.js"></script>
 
         <script>
             $(function() {


### PR DESCRIPTION
Every other resource is loaded using protocol relative URLs, except the one for highlight JS.
